### PR TITLE
Fix raw Markdown on Location page

### DIFF
--- a/_posts/2000-01-05-location.md
+++ b/_posts/2000-01-05-location.md
@@ -19,6 +19,7 @@ The address: Viale Amerigo Vespucci, 20, 47921 Rimini RN, Italia
   src="https://www.google.com/maps/embed/v1/place?key=AIzaSyBTr-Yib3VVO2CA_DnrUYpeWHtLNaQOr4k
     &q=Viale+Amerigo+Vespucci%2C+20%2C+47921+Rimini+RN" allowfullscreen>
 </iframe>
+</div>
 
 ### Directions to SoCraTes Venue
 


### PR DESCRIPTION
I've added a closing div that appeared to be missing. I've not tested the fix, though, sorry: I don't have a Ruby environment available at work :sweat_smile: (No `gem` etc.)
