### PR TITLE
Issues: #45, #46, #47

### DIFF
--- a/cookie-policy/index.html
+++ b/cookie-policy/index.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <meta charset="utf-8">
+        
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-135356462-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('set', {'user_id': 'USER_ID'});
+    gtag('config', 'GA_TRACKING_ID', {'user_id': 'USER_ID'});
+    gtag('config', 'UA-135356462-1');
+    gtag('config', 'GA_TRACKING_ID', { 'anonymize_ip': true });
+</script>
+<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="International Software Craftsmanship and Testing Conference">

--- a/css/agency.css
+++ b/css/agency.css
@@ -1045,3 +1045,9 @@ body {
     position: inherit;
     margin-left: 0px;
 }
+
+.registration-form {
+    border: 2px solid gray;
+    background-color: #eee;
+    border-radius: 5px;
+}

--- a/index.html
+++ b/index.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <meta charset="utf-8">
+        
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-135356462-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('set', {'user_id': 'USER_ID'});
+    gtag('config', 'GA_TRACKING_ID', {'user_id': 'USER_ID'});
+    gtag('config', 'UA-135356462-1');
+    gtag('config', 'GA_TRACKING_ID', { 'anonymize_ip': true });
+</script>
+<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="International Software Craftsmanship and Testing Conference">

--- a/index.xml
+++ b/index.xml
@@ -37,7 +37,7 @@ Scope Anna Piera Frascella, Arialdo Martini, Pierluigi Pugliese, Gabriele Tondi 
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://socrates-conference.it/registration/</guid>
-      <description>Please leave your e-mail here to let us know you would like to attend SoCraTes-IT 2019-- #mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; } /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block. We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */  #mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;} #mergeRow-gdpr {margin-top: 20px;} #mergeRow-gdpr fieldset label {font-weight: normal;} #mc-embedded-subscribe-form .</description>
+      <description>Please leave your e-mail here to let us know you would like to attend SoCraTes-IT 2019-- #mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; }  #mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;} #mergeRow-gdpr {margin-top: 20px;} #mergeRow-gdpr fieldset label {font-weight: normal;} #mc-embedded-subscribe-form .mc_fieldset{border:none;min-height: 0px;padding-bottom:0px;} #mc_embed_signup .button { padding: 10px 30px; border-color: red; border-radius: 3px; text-transform: uppercase; font-family: &#34;HelveticaNeue-Light&#34;, &#34;Helvetica Neue Light&#34;, &#34;Helvetica Neue&#34;, Helvetica, Arial, &#34;Lucida Grande&#34;, sans-serif; font-size: 18px; font-weight: 700; color: #fff; background-color: red; height: auto; } #mc_embed_signup .</description>
     </item>
     
   </channel>

--- a/index.xml
+++ b/index.xml
@@ -37,8 +37,7 @@ Scope Anna Piera Frascella, Arialdo Martini, Pierluigi Pugliese, Gabriele Tondi 
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://socrates-conference.it/registration/</guid>
-      <description>Location We are going to be in the hotel, night and day. That is why, we have chosen the Hotel Continental in Rimini as our location for the unconference.
-Since one of the important aspects of SoCraTes is being close to the “action”, everything will happen within the location: lodging, eating and mingling. As a result, we can only accept as many participants as the number of available beds.</description>
+      <description>Please leave your e-mail here to let us know you would like to attend SoCraTes-IT 2019-- #mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; } /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block. We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */  #mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;} #mergeRow-gdpr {margin-top: 20px;} #mergeRow-gdpr fieldset label {font-weight: normal;} #mc-embedded-subscribe-form .</description>
     </item>
     
   </channel>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <meta charset="utf-8">
+        
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-135356462-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('set', {'user_id': 'USER_ID'});
+    gtag('config', 'GA_TRACKING_ID', {'user_id': 'USER_ID'});
+    gtag('config', 'UA-135356462-1');
+    gtag('config', 'GA_TRACKING_ID', { 'anonymize_ip': true });
+</script>
+<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="International Software Craftsmanship and Testing Conference">

--- a/registration/index.html
+++ b/registration/index.html
@@ -115,14 +115,27 @@
 <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
 <style type="text/css">
     #mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; }
-    /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
-       We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
 </style>
 <style type="text/css">
     #mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;}
     #mergeRow-gdpr {margin-top: 20px;}
     #mergeRow-gdpr fieldset label {font-weight: normal;}
     #mc-embedded-subscribe-form .mc_fieldset{border:none;min-height: 0px;padding-bottom:0px;}
+    #mc_embed_signup .button {
+        padding: 10px 30px;
+        border-color: red;
+        border-radius: 3px;
+        text-transform: uppercase;
+        font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+        font-size: 18px;
+        font-weight: 700;
+        color: #fff;
+        background-color: red;
+        height: auto;
+    }
+    
+    #mc_embed_signup .button:hover {background-color:green;}
+    }
 </style>
 <div id="mc_embed_signup">
 <form action="https://socrates-conference.us20.list-manage.com/subscribe/post?u=4e24ba7602f7acf9fe79737d3&amp;id=be9dbd9e7a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>

--- a/registration/index.html
+++ b/registration/index.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <meta charset="utf-8">
+        
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-135356462-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('set', {'user_id': 'USER_ID'});
+    gtag('config', 'GA_TRACKING_ID', {'user_id': 'USER_ID'});
+    gtag('config', 'UA-135356462-1');
+    gtag('config', 'GA_TRACKING_ID', { 'anonymize_ip': true });
+</script>
+<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="International Software Craftsmanship and Testing Conference">
@@ -96,6 +107,60 @@
                 </div>
                 
 
+<div class="registration-form" style="text-align: center;">
+  <!--<h4>Please leave your e-mail here to let us know you would like to attend SoCraTes-IT 2019</h4>-->
+  
+  
+<!-- Begin Mailchimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+    #mc_embed_signup{clear:left; font:14px Helvetica,Arial,sans-serif; }
+    /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+       We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<style type="text/css">
+    #mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;}
+    #mergeRow-gdpr {margin-top: 20px;}
+    #mergeRow-gdpr fieldset label {font-weight: normal;}
+    #mc-embedded-subscribe-form .mc_fieldset{border:none;min-height: 0px;padding-bottom:0px;}
+</style>
+<div id="mc_embed_signup">
+<form action="https://socrates-conference.us20.list-manage.com/subscribe/post?u=4e24ba7602f7acf9fe79737d3&amp;id=be9dbd9e7a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+    <h2>Secure your seat for SoCraTes IT and register here!</h2>
+<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+<div class="mc-field-group">
+    <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+</label>
+    <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+<div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
+    <div class="content__gdpr">
+        <label>GDPR Permissions</label>
+        <p>Please select all the ways you would like to hear from SoCraTes IT:</p>
+        <fieldset class="mc_fieldset gdprRequired mc-field-group" name="interestgroup_field">
+        <label class="checkbox subfield" for="gdpr_11381"><input type="checkbox" id="gdpr_11381" name="gdpr[11381]" value="Y" class="av-checkbox gdpr"><span>Email</span> </label>
+        </fieldset>
+        <p>You can unsubscribe at any time by clicking the link in the footer of our emails. 
+In compliance with art.6, 12 and 13 of GDPR – General Data Protection Regulation, Reg. UE 679/2016  I declare to have read and understood SoCraTes IT’s privacy policy.</p>
+    </div>
+    <div class="content__gdprLegal">
+        <p>We use Mailchimp as our marketing platform. By clicking below to subscribe, you acknowledge that your information will be transferred to Mailchimp for processing. <a href="https://mailchimp.com/legal/" target="_blank">Learn more about Mailchimp's privacy practices here.</a></p>
+    </div>
+</div>
+    <div id="mce-responses" class="clear">
+        <div class="response" id="mce-error-response" style="display:none"></div>
+        <div class="response" id="mce-success-response" style="display:none"></div>
+    </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_4e24ba7602f7acf9fe79737d3_be9dbd9e7a" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Register now" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!--End mc_embed_signup-->
+</div>
+
 <h2 id="location">Location</h2>
 
 <p>We are going to be in the hotel, night and day. That is why, we have chosen the <a href="https://www.hotelcontinentalrimini.it/">Hotel Continental</a> in Rimini as our location for the unconference.</p>
@@ -117,9 +182,7 @@ number of available beds.</p>
 <ul>
 <li><strong>unconference’s services</strong>:<br />the total amount will be about 3.000€ and it will be divided between all attendees.
 You will pay your part at the checkout.<br /><br /></li>
-<li><strong>2 nights full-board + the city tax</strong>:<br /> the hotel has both twin or double rooms. If there is someone you
-are willing to share the room with, please let us know when you register. If you don’t know anyone,
-don’t worry: we will do our best to find you a suitable roommate ;-)
+<li>the hotel has both twin or double rooms. If there is someone you are willing to share the room with, please let us know when you register. If you don’t know anyone, don’t worry: we will do our best to find you a suitable roommate.
 <br />
 <br /></li>
 </ul>
@@ -154,60 +217,6 @@ don’t worry: we will do our best to find you a suitable roommate ;-)
             </div>
         </div>
     </div>
-</div>
-
-<div style="text-align: center;">
-  <!--<h4>Please leave your e-mail here to let us know you would like to attend SoCraTes-IT 2019</h4>-->
-  
-  
-<!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-    #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
-    /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
-       We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
-</style>
-<style type="text/css">
-    #mc-embedded-subscribe-form input[type=checkbox]{display: inline; width: auto;margin-right: 10px;}
-    #mergeRow-gdpr {margin-top: 20px;}
-    #mergeRow-gdpr fieldset label {font-weight: normal;}
-    #mc-embedded-subscribe-form .mc_fieldset{border:none;min-height: 0px;padding-bottom:0px;}
-</style>
-<div id="mc_embed_signup">
-<form action="https://socrates-conference.us20.list-manage.com/subscribe/post?u=4e24ba7602f7acf9fe79737d3&amp;id=be9dbd9e7a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-    <h2>Secure your seat for SoCraTes IT and pre-register here!</h2>
-<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-<div class="mc-field-group">
-    <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
-</label>
-    <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-</div>
-<div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
-    <div class="content__gdpr">
-        <label>GDPR Permissions</label>
-        <p>Please select all the ways you would like to hear from SoCraTes IT:</p>
-        <fieldset class="mc_fieldset gdprRequired mc-field-group" name="interestgroup_field">
-        <label class="checkbox subfield" for="gdpr_11381"><input type="checkbox" id="gdpr_11381" name="gdpr[11381]" value="Y" class="av-checkbox gdpr"><span>Email</span> </label>
-        </fieldset>
-        <p>You can unsubscribe at any time by clicking the link in the footer of our emails. 
-In compliance with art.6, 12 and 13 of GDPR – General Data Protection Regulation, Reg. UE 679/2016  I declare to have read and understood SoCraTes IT’s privacy policy.</p>
-    </div>
-    <div class="content__gdprLegal">
-        <p>We use Mailchimp as our marketing platform. By clicking below to subscribe, you acknowledge that your information will be transferred to Mailchimp for processing. <a href="https://mailchimp.com/legal/" target="_blank">Learn more about Mailchimp's privacy practices here.</a></p>
-    </div>
-</div>
-    <div id="mce-responses" class="clear">
-        <div class="response" id="mce-error-response" style="display:none"></div>
-        <div class="response" id="mce-success-response" style="display:none"></div>
-    </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_4e24ba7602f7acf9fe79737d3_be9dbd9e7a" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Register now" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
-<!--End mc_embed_signup-->
 </div>
 
             </div>


### PR DESCRIPTION
See [45](https://github.com/socrates-it-test/site-source/issues/45), [46](https://github.com/socrates-it-test/site-source/issues/46), [47](https://github.com/socrates-it-test/site-source/issues/47)

* Explaination on rooms availability is clearer;
* IPs are anonymized;
* Google Analytics uses User ID;
* the Registration Form is on the page top, and surrounded by a gray border;
* the registration button in the MailChimp form is red, and it turns to green on hover, instead of the default gray MailChimp button.

The PR is already rebased on e111557ecdb5687fa04f2203ac0a183764b6f12e